### PR TITLE
Fix one-lined rescue

### DIFF
--- a/lib/blockmap-compiler.coffee
+++ b/lib/blockmap-compiler.coffee
@@ -1,6 +1,7 @@
 openKeywords = /begin|case|class|def|do|for|module|while/
 ifOrUnlessKeyword = /if|unless/
-intermediateKeywords = /else|elsif|ensure|rescue/
+intermediateKeywords = /else|elsif|ensure/
+notInlineRescue = /^\s*rescue/
 endKeyword = /end/
 
 class Parameters
@@ -54,7 +55,7 @@ class Stack
     # TODO
     # this handles the intermediates first, because of the if that also appears
     # in elsif. maybe this should be taken care of with a more specific regex.
-    if intermediateKeywords.test(parameters.keyword)
+    if intermediateKeywords.test(parameters.keyword) || notInlineRescue.test(line)
       @getTop()?.pushInbetween(parameters)
 
     else if ifOrUnlessKeyword.test(parameters.keyword)

--- a/spec/blockmap-compiler-spec.coffee
+++ b/spec/blockmap-compiler-spec.coffee
@@ -128,3 +128,15 @@ describe "compile", ->
         expect(map[1][10].parameters.keyword).toBe "unless"
         expect(map[3][2].parameters.keyword).toBe "else"
         expect(map[5][2].parameters.keyword).toBe "end"
+
+  describe "rescue statements", ->
+    describe "one-line rescue", ->
+      beforeEach ->
+        prepare("one-line-rescue.rb")
+
+      it "ignores them", ->
+        expect(_.keys(map).length).toBe 2
+        expect(map[0][0].parameters.keyword).toBe "def"
+        expect(map[1]).toBe undefined
+        expect(map[2]).toBe undefined
+        expect(map[3][0].parameters.keyword).toBe "end"

--- a/spec/fixtures/one-line-rescue.rb
+++ b/spec/fixtures/one-line-rescue.rb
@@ -1,0 +1,4 @@
+def will_not_fail
+  anything
+  dangerous! rescue safe
+end


### PR DESCRIPTION
![incorrect-rescue-highlight](https://cloud.githubusercontent.com/assets/232243/15991339/4c4ece94-30c1-11e6-8939-ee93116d1441.png)
The screenshot above is how it looks for now, but `rescue` here is not a part of `def/end`