### PR TITLE
Highlight Ruby on Rails as well

### DIFF
--- a/lib/blocky.coffee
+++ b/lib/blocky.coffee
@@ -3,7 +3,7 @@ BlockyView = null
 module.exports = Blocky =
   activate: ->
     atom.workspace.observeTextEditors (editor) =>
-      if editor.getGrammar().name is "Ruby"
+      if editor.getGrammar().name in ["Ruby", "Ruby on Rails"]
         BlockyView ?= require './blocky-view'
         editorElement = atom.views.getView(editor)
         new BlockyView(editor, editorElement)


### PR DESCRIPTION
Don't know why, but some projects Atom opens as "Ruby on Rails" syntax (interesting, what's the difference with plain Ruby? :-) ). And `blocky` doesn't highlight keywords in such cases. Here's a fix. And, I don't know how to test it, so there's no tests