### PR TITLE
Fix highlight for 'extend' and 'defined?'

### DIFF
--- a/lib/blockmap-compiler.coffee
+++ b/lib/blockmap-compiler.coffee
@@ -1,8 +1,8 @@
-openKeywords = /begin|case|class|def|do|for|module|while/
+openKeywords = /^(begin|case|class|def|do|for|module|while)$/
 ifOrUnlessKeyword = /if|unless/
 intermediateKeywords = /else|elsif|ensure/
 notInlineRescue = /^\s*rescue/
-endKeyword = /end/
+endKeyword = /^end$/
 
 class Parameters
   constructor: (@keyword, @lineNumber, @position, @length) ->

--- a/spec/blockmap-compiler-spec.coffee
+++ b/spec/blockmap-compiler-spec.coffee
@@ -67,6 +67,28 @@ describe "compile", ->
       it "doesnt throw errors if it cant match all pairs", ->
         expect(map).toBeDefined()
 
+    describe "when there are keywords, that includes other keywords", ->
+
+      describe "extend keywords", ->
+        beforeEach ->
+          prepare('extend.rb')
+
+        it "ignores them", ->
+          expect(_.keys(map).length).toBe 2
+          expect(map[0][0].parameters.keyword).toBe "class"
+          expect(map[1]).toBe undefined
+          expect(map[2][0].parameters.keyword).toBe "end"
+
+      describe "defined? keywords", ->
+        beforeEach ->
+          prepare('defined.rb')
+
+        it "ignores them", ->
+          expect(_.keys(map).length).toBe 2
+          expect(map[0][0].parameters.keyword).toBe "def"
+          expect(map[1]).toBe undefined
+          expect(map[2][0].parameters.keyword).toBe "end"
+
   describe "if statements", ->
     describe "basic if", ->
       beforeEach ->

--- a/spec/fixtures/defined.rb
+++ b/spec/fixtures/defined.rb
@@ -1,0 +1,3 @@
+def test_method
+  return true defined? something
+end

--- a/spec/fixtures/extend.rb
+++ b/spec/fixtures/extend.rb
@@ -1,0 +1,3 @@
+class TestClass
+  extend Other
+end


### PR DESCRIPTION
Fix highlight for `extend` and `defined?` keywords. See screenshots how it looks for now:

![incorrect-extend-highlight](https://cloud.githubusercontent.com/assets/232243/16133663/1e94e940-342a-11e6-86df-1b330e994738.png)

![incorrect-defined-highlight](https://cloud.githubusercontent.com/assets/232243/16133774/a8d08524-342a-11e6-986f-17a37ec2e867.png)

